### PR TITLE
Improve main routing with other small fixes

### DIFF
--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -111,31 +111,33 @@ def handle_control():
     while True:
         try:
             message = wsock.receive()
-            log.info("Received (control): %s" % message)
-            msgdict = json.loads(message)
-            if msgdict.get("cmd") == "RUN":
-                log.info("RUN command received")
-                profile_obj = msgdict.get('profile')
-                if profile_obj:
-                    profile_json = json.dumps(profile_obj)
-                    profile = Profile(profile_json)
-                oven.run_profile(profile)
-                ovenWatcher.record(profile)
-            elif msgdict.get("cmd") == "SIMULATE":
-                log.info("SIMULATE command received")
-                #profile_obj = msgdict.get('profile')
-                #if profile_obj:
-                #    profile_json = json.dumps(profile_obj)
-                #    profile = Profile(profile_json)
-                #simulated_oven = Oven(simulate=True, time_step=0.05)
-                #simulation_watcher = OvenWatcher(simulated_oven)
-                #simulation_watcher.add_observer(wsock)
-                #simulated_oven.run_profile(profile)
-                #simulation_watcher.record(profile)
-            elif msgdict.get("cmd") == "STOP":
-                log.info("Stop command received")
-                oven.abort_run()
-        except WebSocketError:
+            if message:
+                log.info("Received (control): %s" % message)
+                msgdict = json.loads(message)
+                if msgdict.get("cmd") == "RUN":
+                    log.info("RUN command received")
+                    profile_obj = msgdict.get('profile')
+                    if profile_obj:
+                        profile_json = json.dumps(profile_obj)
+                        profile = Profile(profile_json)
+                    oven.run_profile(profile)
+                    ovenWatcher.record(profile)
+                elif msgdict.get("cmd") == "SIMULATE":
+                    log.info("SIMULATE command received")
+                    #profile_obj = msgdict.get('profile')
+                    #if profile_obj:
+                    #    profile_json = json.dumps(profile_obj)
+                    #    profile = Profile(profile_json)
+                    #simulated_oven = Oven(simulate=True, time_step=0.05)
+                    #simulation_watcher = OvenWatcher(simulated_oven)
+                    #simulation_watcher.add_observer(wsock)
+                    #simulated_oven.run_profile(profile)
+                    #simulation_watcher.record(profile)
+                elif msgdict.get("cmd") == "STOP":
+                    log.info("Stop command received")
+                    oven.abort_run()
+        except WebSocketError as e:
+            log.error(e)
             break
     log.info("websocket (control) closed")
 

--- a/kiln-controller.py
+++ b/kiln-controller.py
@@ -11,6 +11,7 @@ import geventwebsocket
 #from bottle import post, get
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
+from geventwebsocket import WebSocketError
 
 
 try:

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -98,7 +98,9 @@ class Oven (threading.Thread):
         pid = 0
         while True:
 
-            if self.state == Oven.STATE_RUNNING:
+            if self.state == Oven.STATE_IDLE:
+                time.sleep(1)
+            elif self.state == Oven.STATE_RUNNING:
                 if self.simulate:
                     self.runtime += 0.5
                 else:
@@ -137,13 +139,14 @@ class Oven (threading.Thread):
                 if(self.temp_sensor.temperature + config.thermocouple_offset >= config.emergency_shutoff_temp):
                     log.info("emergency!!! temperature too high, shutting down")
                     self.reset()
-                    
-                #Capture the last temperature value.  This must be done before set_heat, since there is a sleep in there now.
+
+                # Capture the last temperature value.  This must be done before set_heat,
+                # since there is a sleep in there now.
                 last_temp = self.temp_sensor.temperature + config.thermocouple_offset
-                
+
                 self.set_heat(pid)
 
-                if self.runtime >= self.totaltime:
+                if self.runtime > self.totaltime:
                     log.info("schedule ended, shutting down")
                     self.reset()
 

--- a/lib/oven.py
+++ b/lib/oven.py
@@ -118,7 +118,7 @@ class Oven (threading.Thread):
                     heat_off = float(self.time_step * (1 - pid))
                 time_left = self.totaltime - self.runtime
 
-                log.info("temp=%.1f, target=%.1f, pid=%.3f, heat_on=%.2f, heat_off=%.2f, run_time=%d, total_time=%d, time_left=%d" % 
+                log.info("temp=%.1f, target=%.1f, pid=%.3f, heat_on=%.2f, heat_off=%.2f, run_time=%d, total_time=%d, time_left=%d" %
                     (self.temp_sensor.temperature + config.thermocouple_offset,
                      self.target,
                      pid,
@@ -161,13 +161,13 @@ class Oven (threading.Thread):
                if config.heater_invert:
                  GPIO.output(config.gpio_heat, GPIO.LOW)
                  time.sleep(self.time_step * value)
-                 GPIO.output(config.gpio_heat, GPIO.HIGH)   
+                 GPIO.output(config.gpio_heat, GPIO.HIGH)
                else:
                  GPIO.output(config.gpio_heat, GPIO.HIGH)
                  time.sleep(self.time_step * value)
                  GPIO.output(config.gpio_heat, GPIO.LOW)
             else:
-                 #for runs that are simulations
+                 # for runs that are simulations
                  time.sleep(self.time_step * value)
         else:
             self.heat = 0.0
@@ -224,7 +224,7 @@ class TempSensorReal(TempSensor):
 
             maxtries = 5
             sleeptime = self.time_step / float(maxtries)
-            maxtemp = 0 
+            maxtemp = 0
             for x in range(0,maxtries):
                 try:
                     temp = self.thermocouple.get()

--- a/lib/ovenWatcher.py
+++ b/lib/ovenWatcher.py
@@ -66,10 +66,10 @@ class OvenWatcher(threading.Thread):
             'log': self.lastlog_subset(),
             #'started': self.started
         }
-        print (backlog)
+        print(backlog)
         backlog_json = json.dumps(backlog)
         try:
-            print (backlog_json)
+            print(backlog_json)
             observer.send(backlog_json)
         except:
             log.error("Could not send backlog to new observer")


### PR DESCRIPTION
Issues

    ovenWatcher: erroneous spaces in print statements
    oven: reset() called twice on run abort
    oven: When in idle state the while loop overloads the cpu with iterations
    kiln-controller: missing import for WebSocketError
    kiln-controller: TyperError thrown in a websocket message of None is received

Solutions

    remove spaces
    Make reset on schedule completion when run time > total time, not >=
    Add a sleep of 1second for each loop iteration when in idle state
    Add missing import
    Only handle message if not false/none
